### PR TITLE
Clean up VB rule feature names to make sure they always are identifiers

### DIFF
--- a/acapulco.cpcogen/src/main/java/acapulco/rulesgeneration/activationdiagrams/FeatureActivationSubDiagram.xtend
+++ b/acapulco.cpcogen/src/main/java/acapulco/rulesgeneration/activationdiagrams/FeatureActivationSubDiagram.xtend
@@ -238,7 +238,14 @@ class FeatureActivationSubDiagram {
 	}
 
 	private dispatch def String getName(FeatureDecision fd) {
-		fd.feature.name + (fd.activate ? "Act" : "DeAct")
+		fd.feature.name.sanitise + (fd.activate ? "Act" : "DeAct")
+	}
+	
+	/**
+	 * Sanitise feature names so they can serve as variable identifiers in the formula given to the SAT solver 
+	 */
+	private def sanitise(String featureName) {
+		featureName.replaceAll("\\W", "")
 	}
 
 	private def resolveAndSimplify(Set<PresenceCondition> presenceConditions) {


### PR DESCRIPTION
This should help with real-world feature models, where feature names might include non-ID characters, especially white space. 

Such characters would lead to an unparseable constraint expression string in the VB rule. This PR removes all of these characters from the feature names so that the resulting VB-rule feature names should again result in parseable constraint expressions.